### PR TITLE
update plug to 1.5 to be used with phoenix html 2.11.1

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -22,7 +22,7 @@ defmodule PlugDatadogStats.Mixfile do
   defp deps do
     [
       {:ex_statsd, github: "PagerDuty/ex_statsd", ref: "a5c1aefd1d8d273e3910c2ae53c034669f792400"}, # Pulling in Cees' socket open fix
-      {:plug, ">= 1.3.2 and ~> 1.3"},
+      {:plug, ">= 1.5.1 and ~> 1.5"},
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,5 @@
-%{"ex_statsd": {:git, "https://github.com/PagerDuty/ex_statsd.git", "a5c1aefd1d8d273e3910c2ae53c034669f792400", [ref: "a5c1aefd1d8d273e3910c2ae53c034669f792400"]},
-  "mime": {:hex, :mime, "1.1.0", "01c1d6f4083d8aa5c7b8c246ade95139620ef8effb009edde934e0ec3b28090a", [:mix], []},
-  "plug": {:hex, :plug, "1.3.5", "7503bfcd7091df2a9761ef8cecea666d1f2cc454cbbaf0afa0b6e259203b7031", [:mix], [{:cowboy, "~> 1.0.1 or ~> 1.1", [hex: :cowboy, optional: true]}, {:mime, "~> 1.0", [hex: :mime, optional: false]}]}}
+%{
+  "ex_statsd": {:git, "https://github.com/PagerDuty/ex_statsd.git", "a5c1aefd1d8d273e3910c2ae53c034669f792400", [ref: "a5c1aefd1d8d273e3910c2ae53c034669f792400"]},
+  "mime": {:hex, :mime, "1.3.0", "5e8d45a39e95c650900d03f897fbf99ae04f60ab1daa4a34c7a20a5151b7a5fe", [:mix], [], "hexpm"},
+  "plug": {:hex, :plug, "1.5.1", "1ff35bdecfb616f1a2b1c935ab5e4c47303f866cb929d2a76f0541e553a58165", [:mix], [{:cowboy, "~> 1.0.1 or ~> 1.1 or ~> 2.3", [hex: :cowboy, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}], "hexpm"},
+}


### PR DESCRIPTION
Update plug to be compatible with phoenix_html 2.11.1. This version coincides with phoenix `~> 1.3.2`. 

@PagerDuty/im-data not sure what the steps are to tag/get this live. Any help would be greatly appreciated.