### PR TITLE
Stop rampant tag creation when path includes un-regexable params

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,44 @@
+version: 2
+elixir_image: &elixir_image
+  image: circleci/elixir:1.8.1
+
+merge_master: &merge_master
+  name: Fetch PR merge commit
+  command: |
+    # Merges master into our PR and fails if we have a conflict on that
+    if [[ -n "${CIRCLE_PULL_REQUEST}" ]]; then
+      git fetch origin master
+      git config --global user.email "circleci@pagerduty.com"
+      git config --global user.name "circleci"
+      git rebase origin/master
+      if [[ $? -ne 0 ]]; then
+        echo "Merge conflict detected; aborting. Please manually fix the conflict and retry."
+        exit 1
+      fi
+    fi
+elixir_setup: &elixir_setup
+  name: Set up Elixir environment
+  command: |
+    mix local.hex --force --if-missing
+    mix local.rebar --force
+    mix deps.get
+jobs:
+  test:
+    docker:
+      - image: circleci/elixir:1.8.1
+    steps:
+      - checkout
+      - run: ssh-add -D && echo "${GITHUB_SSH_KEY}" | base64 --decode | ssh-add - # to access private Github deps
+      - run:
+          <<: *merge_master
+      - run:
+          <<: *elixir_setup
+      - run:
+          name: 'run test suites for all subprojects'
+          command: mix test
+workflows:
+  version: 2
+  test_and_publish:
+    jobs:
+      - test:
+          context: PagerDuty

--- a/README.md
+++ b/README.md
@@ -45,3 +45,81 @@ defmodule YourPlugBasedThing.Endpoint do
   ...
 end
 ```
+
+## Handling Non-standard Path Parameters
+
+Sometimes we have paths that have path parameters that are not easily
+matchable using regular expressions.
+
+A simple example would be this:
+`/api/v1/status_service/slug/my-custom-slug-4`
+
+A more complex example might look like this:
+`/api/v1/status_service/slug/my-custom-slug-4/views/my-user-readable-view-id`
+
+`PlugDatadogStats` will interpret each of these as a separate path and create a tag
+for all of them which is Not Desirable™.
+
+### Some Potential Approaches
+
+#### Anonymous function
+
+This requires the most work from the user of the plug.  However I think this should likely
+be the approach we take until we hear that many people are running in to this issue.
+
+```elixir
+# The function should return a list in the shape of
+# conn.path_info but with fields removed for dd tags
+# Example: ["api", "v1", "status_service", "slug", "OBFUSCATED"]
+
+pre_plug PlugDatadogStats, path_normalize_fn: fn
+  ["api", "v1", "status_service", "slug", slug_one, "views", slug_two] = path ->
+    path
+    |> Enum.map(fn 
+      ^slug_one ->
+        "SLUG"
+
+      ^slug_two ->
+        "OTHER_SLUG"
+
+      segment ->
+        segment
+      end
+    )
+
+  path ->
+    path
+end
+```
+
+#### Override Through `assigns`
+
+This is similar to the above function but we leave it up to the user
+to figure out how to generate that data structure.  One piece of this that could
+change would be that we'd just require them to add it under a certain key in `assigns`
+rather than letting them specify their own.
+
+```elixir
+# User writes another plug (or otherwise modifies conn.assigns).  It should add
+# something under a key in assigns that is a list mirroring the
+# shape of conn.path_info but with fields removed for dd tags
+# Example: ["api", "v1", "status_service", "slug", "OBFUSCATED"]
+
+pre_plug PathParamOverride 
+pre_plug PlugDatadogStats, path_info_override: :dd_path_tag_override # :dd_path_tag_override was added to the assigns by PathParamOverride
+```
+
+#### Metaprogramming Madness (MM)
+
+This approach would take in a pattern as shown below, and autogenerate matchers within the plug
+to normalize requests matching the patter.  This would require some metaprogramming in the plug
+but would require the least knowledge from the user of the library about the inner workings
+of the library.
+
+```elixir
+# Metaprogramming in the plug generates methods that do something similar to the first example
+pre_plug PlugDatadogStats, normalize_patterns: [
+  ["api", "v1", "status_service", "slug", {:replace, "SLUG"}],
+  ["api", "v1", "status_service", "slug", {:replace, "SLUG"}, "views", {:replace, "OTHER_SLUG"}]
+]
+```

--- a/README.md
+++ b/README.md
@@ -60,66 +60,17 @@ A more complex example might look like this:
 `PlugDatadogStats` will interpret each of these as a separate path and create a tag
 for all of them which is Not Desirable™.
 
-### Some Potential Approaches
-
-#### Anonymous function
-
-This requires the most work from the user of the plug.  However I think this should likely
-be the approach we take until we hear that many people are running in to this issue.
+To handle cases like this, you can pass the plug a `path_normalize_fn`
+option that explicitly matches on the path patterns you expect:
 
 ```elixir
-# The function should return a list in the shape of
-# conn.path_info but with fields removed for dd tags
-# Example: ["api", "v1", "status_service", "slug", "OBFUSCATED"]
-
-pre_plug PlugDatadogStats, path_normalize_fn: fn
-  ["api", "v1", "status_service", "slug", slug_one, "views", slug_two] = path ->
-    path
-    |> Enum.map(fn 
-      ^slug_one ->
-        "SLUG"
-
-      ^slug_two ->
-        "OTHER_SLUG"
-
-      segment ->
-        segment
-      end
-    )
-
-  path ->
-    path
+# This can be defined in any other module.  For this example it is defined in the
+# same module that the plug is added to the pipeline
+def path_param_override(["api", "v1", "status_service", "slug", _slug]) do
+  ["api", "v1", "status_service", "slug", "SLUG"]
 end
-```
 
-#### Override Through `assigns`
+def path_param_override(path_info), do: path_info # be sure to include the base case
 
-This is similar to the above function but we leave it up to the user
-to figure out how to generate that data structure.  One piece of this that could
-change would be that we'd just require them to add it under a certain key in `assigns`
-rather than letting them specify their own.
-
-```elixir
-# User writes another plug (or otherwise modifies conn.assigns).  It should add
-# something under a key in assigns that is a list mirroring the
-# shape of conn.path_info but with fields removed for dd tags
-# Example: ["api", "v1", "status_service", "slug", "OBFUSCATED"]
-
-pre_plug PathParamOverride 
-pre_plug PlugDatadogStats, path_info_override: :dd_path_tag_override # :dd_path_tag_override was added to the assigns by PathParamOverride
-```
-
-#### Metaprogramming Madness (MM)
-
-This approach would take in a pattern as shown below, and autogenerate matchers within the plug
-to normalize requests matching the patter.  This would require some metaprogramming in the plug
-but would require the least knowledge from the user of the library about the inner workings
-of the library.
-
-```elixir
-# Metaprogramming in the plug generates methods that do something similar to the first example
-pre_plug PlugDatadogStats, normalize_patterns: [
-  ["api", "v1", "status_service", "slug", {:replace, "SLUG"}],
-  ["api", "v1", "status_service", "slug", {:replace, "SLUG"}, "views", {:replace, "OTHER_SLUG"}]
-]
+pre_plug PlugDatadogStats, path_normalize_fn: {__MODULE__, :path_param_override, []}
 ```

--- a/lib/plug_datadog_stats.ex
+++ b/lib/plug_datadog_stats.ex
@@ -1,43 +1,69 @@
 defmodule PlugDatadogStats do
   @behaviour Plug
-  import Plug.Conn, only: [register_before_send: 2]
+  import Plug.Conn, only: [register_before_send: 2, put_private: 3]
   require Logger
 
-  def init(_) do
-    %{
-      histogram: Application.get_env(:plug_datadog_stats, :histogram_name, "resp_time"),
-      count: Application.get_env(:plug_datadog_stats, :count_name, "resp_count"),
-    }
+  @base_opts %{
+    histogram: Application.get_env(:plug_datadog_stats, :histogram_name, "resp_time"),
+    count: Application.get_env(:plug_datadog_stats, :count_name, "resp_count"),
+    path_normalize_fn: {__MODULE__, :path_override_passthrough, []}
+  }
+
+  def init(opts \\ []) do
+    opts
+    |> Enum.into(@base_opts)
+    |> parse_options()
   end
 
-  def call(conn, names) do
-    req_start_time = :os.timestamp
+  def call(conn, opts) do
+    req_start_time = :os.timestamp()
 
-    register_before_send conn, fn conn ->
-      tags = tags_for_conn(conn)
-
+    register_before_send(conn, fn conn ->
       # This will log response time in microseconds
-      req_end_time = :os.timestamp
+      req_end_time = :os.timestamp()
       duration = :timer.now_diff(req_end_time, req_start_time)
 
-      Logger.debug("PlugDatadogStats: #{duration}µs #{names.histogram}/#{names.count} #{inspect tags}")
-      ExStatsD.histogram(duration, names.histogram, tags: tags)
-      ExStatsD.increment(names.count, tags: tags)
+      tags = tags_for_conn(conn, opts.path_normalize_fn)
 
-      conn
-    end
+      Logger.debug(
+        "PlugDatadogStats: #{duration}µs #{opts.histogram}/#{opts.count} #{inspect(tags)}"
+      )
+
+      ExStatsD.histogram(duration, opts.histogram, tags: tags)
+      ExStatsD.increment(opts.count, tags: tags)
+
+      # Tags are added to the conn for testing and observability purposes
+      put_private(conn, :plug_datadog_stats_tags, tags)
+    end)
   end
 
-  defp tags_for_conn(conn) do
+  defp parse_options(%{path_normalize_fn: {_m, _f, _a}} = opts) do
+    opts
+  end
+
+  defp parse_options(%{path_normalize_fn: _bad}) do
+    raise """
+      The path_normalize_fn option should be provided in the format {module, function, arguments}.
+
+      Example: PlugDatadogStats, path_normalize_fn: {MyModule, :function_name, []}
+    """
+  end
+
+  defp parse_options(opts), do: opts
+
+  defp tags_for_conn(conn, path_normalize_fn) do
+    path_for_tag = generalize_path(conn.path_info, path_normalize_fn)
+
     [
       "method:#{conn.method}",
       "status:#{conn.status}",
-      "endpoint:#{generalize_path(conn.path_info)}",
+      "endpoint:#{path_for_tag}"
     ]
   end
 
-  defp generalize_path(path_info) do
+  defp generalize_path(path_info, path_normalize_fn) do
     path_info
+    |> apply_path_normalize_fn(path_normalize_fn)
     |> Enum.map(&normalize_segment/1)
     |> Enum.join("/")
   end
@@ -46,16 +72,29 @@ defmodule PlugDatadogStats do
     cond do
       String.match?(segment, ~r/^[0-9]+$/) ->
         "INT"
-      String.match?(segment, ~r/^[a-f0-9]{8}(-[a-f0-9]{4}){3}-[a-f0-9]{12}$/)  ->
+
+      String.match?(segment, ~r/^[a-f0-9]{8}(-[a-f0-9]{4}){3}-[a-f0-9]{12}$/) ->
         "UUID"
+
       String.match?(segment, ~r/^[pP]\w{6}$/) ->
         "OBFUSCATED_ID"
+
       String.match?(segment, ~r/^[qQ]\w{13}$/) ->
         "OBFUSCATED_ID"
+
       String.match?(segment, ~r/^[rR]\w{25}$/) ->
         "OBFUSCATED_ID"
+
       true ->
         segment
     end
+  end
+
+  defp apply_path_normalize_fn(path_info, {m, f, a}) do
+    apply(m, f, [path_info | a])
+  end
+
+  def path_override_passthrough(path_info) do
+    path_info
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -23,6 +23,7 @@ defmodule PlugDatadogStats.Mixfile do
     [
       {:ex_statsd, github: "PagerDuty/ex_statsd", ref: "a5c1aefd1d8d273e3910c2ae53c034669f792400"}, # Pulling in Cees' socket open fix
       {:plug, ">= 1.5.1 and ~> 1.5"},
+      {:mix_test_watch, "~> 0.9", only: :dev, runtime: false},
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,7 @@
 %{
   "ex_statsd": {:git, "https://github.com/PagerDuty/ex_statsd.git", "a5c1aefd1d8d273e3910c2ae53c034669f792400", [ref: "a5c1aefd1d8d273e3910c2ae53c034669f792400"]},
+  "file_system": {:hex, :file_system, "0.2.7", "e6f7f155970975789f26e77b8b8d8ab084c59844d8ecfaf58cbda31c494d14aa", [:mix], [], "hexpm"},
   "mime": {:hex, :mime, "1.3.0", "5e8d45a39e95c650900d03f897fbf99ae04f60ab1daa4a34c7a20a5151b7a5fe", [:mix], [], "hexpm"},
+  "mix_test_watch": {:hex, :mix_test_watch, "0.9.0", "c72132a6071261893518fa08e121e911c9358713f62794a90c95db59042af375", [:mix], [{:file_system, "~> 0.2.1 or ~> 0.3", [hex: :file_system, repo: "hexpm", optional: false]}], "hexpm"},
   "plug": {:hex, :plug, "1.5.1", "1ff35bdecfb616f1a2b1c935ab5e4c47303f866cb929d2a76f0541e553a58165", [:mix], [{:cowboy, "~> 1.0.1 or ~> 1.1 or ~> 2.3", [hex: :cowboy, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}], "hexpm"},
 }

--- a/test/plug_datadog_stats_test.exs
+++ b/test/plug_datadog_stats_test.exs
@@ -1,8 +1,156 @@
 defmodule PlugDatadogStatsTest do
   use ExUnit.Case
   use Plug.Test
+  alias Plug.Conn
 
-  alias PlugDatadogStats
+  defmodule PathInfoToTags do
+    def normalize do
+      :ok
+    end
+  end
 
+  describe "generated tags" do
+    test "generates the expected tags for a basic path request" do
+      conn =
+        %Conn{method: "GET", status: 200, path_info: ["api", "v1", "status_views"]}
+        |> PlugDatadogStats.call(PlugDatadogStats.init([]))
 
+      [before_send_fn] = conn.before_send
+
+      assert %{
+               private: %{
+                 plug_datadog_stats_tags: [
+                   "method:GET",
+                   "status:200",
+                   "endpoint:api/v1/status_views"
+                 ]
+               }
+             } = before_send_fn.(conn)
+    end
+
+    test "generates the expected tags for an unpredictable path param" do
+      defmodule MyOverrideTest do
+        def define_overrides(["api", "v1", "status_views", _slug]) do
+          ["api", "v1", "status_views", "SLUG"]
+        end
+
+        def define_overrides(path_info), do: path_info
+      end
+
+      conn =
+        %Conn{
+          method: "GET",
+          status: 200,
+          path_info: ["api", "v1", "status_views", "big-strong-bear"]
+        }
+        |> PlugDatadogStats.call(
+          PlugDatadogStats.init(path_normalize_fn: {MyOverrideTest, :define_overrides, []})
+        )
+
+      [before_send_fn] = conn.before_send
+
+      assert %{
+               private: %{
+                 plug_datadog_stats_tags: [
+                   "method:GET",
+                   "status:200",
+                   "endpoint:api/v1/status_views/SLUG"
+                 ]
+               }
+             } = before_send_fn.(conn)
+    end
+
+    test "generates the expected tags for multiple unpredictable path params" do
+      defmodule MyOverrideTest do
+        def define_overrides(["api", "v1", "status_views", _slug, "owner_name", _owner_slug]) do
+          ["api", "v1", "status_views", "SLUG", "owner_name", "OWNER_SLUG"]
+        end
+
+        def define_overrides(path_info), do: path_info
+      end
+
+      conn =
+        %Conn{
+          method: "GET",
+          status: 200,
+          path_info: ["api", "v1", "status_views", "big-strong-bear", "owner_name", "mr-steve"]
+        }
+        |> PlugDatadogStats.call(
+          PlugDatadogStats.init(path_normalize_fn: {MyOverrideTest, :define_overrides, []})
+        )
+
+      [before_send_fn] = conn.before_send
+
+      assert %{
+               private: %{
+                 plug_datadog_stats_tags: [
+                   "method:GET",
+                   "status:200",
+                   "endpoint:api/v1/status_views/SLUG/owner_name/OWNER_SLUG"
+                 ]
+               }
+             } = before_send_fn.(conn)
+    end
+
+    test "leaves a path that does not match the pattern alone" do
+      defmodule MyOverrideTest do
+        def define_overrides(["api", "v1", "status_views", _slug]) do
+          ["api", "v1", "status_views", "SLUG"]
+        end
+
+        def define_overrides(path_info), do: path_info
+      end
+
+      conn =
+        %Conn{
+          method: "GET",
+          status: 200,
+          path_info: ["api", "v1", "status_views", "active", "mine"]
+        }
+        |> PlugDatadogStats.call(
+          PlugDatadogStats.init(path_normalize_fn: {MyOverrideTest, :define_overrides, []})
+        )
+
+      [before_send_fn] = conn.before_send
+
+      assert %{
+               private: %{
+                 plug_datadog_stats_tags: [
+                   "method:GET",
+                   "status:200",
+                   "endpoint:api/v1/status_views/active/mine"
+                 ]
+               }
+             } = before_send_fn.(conn)
+    end
+  end
+
+  describe "path_normalize_fn as mfa" do
+    test "consumes without error" do
+      assert %{
+               histogram: histogram_config,
+               count: count_config,
+               path_normalize_fn: {PathInfoToTags, :normalize, []}
+             } = PlugDatadogStats.init(path_normalize_fn: {PathInfoToTags, :normalize, []})
+    end
+  end
+
+  describe "path_normalize_fn is other type" do
+    test "won't compile" do
+      assert_raise RuntimeError, ~r/should be provided in the format \{module, function, arguments\}/, fn ->
+        defmodule BadModule do
+          @opts PlugDatadogStats.init(path_normalize_fn: fn -> :ok end)
+        end
+      end
+    end
+  end
+
+  describe "no options" do
+    test "intializes without error with no app-specific config" do
+      assert %{
+               histogram: "resp_time",
+               count: "resp_count"
+             } = PlugDatadogStats.init()
+    end
+  end
 end

--- a/test/plug_datadog_stats_test.exs
+++ b/test/plug_datadog_stats_test.exs
@@ -1,0 +1,8 @@
+defmodule PlugDatadogStatsTest do
+  use ExUnit.Case
+  use Plug.Test
+
+  alias PlugDatadogStats
+
+
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()


### PR DESCRIPTION
# What
If the user has path params that cannot be predictably matched using a regex as we do with many of our obfuscated ids, give them a mechanism to specify which sections of their path are considered path params.

See the readme for an explanation.

## Context
Jira ticket for original problem: https://pagerduty.atlassian.net/browse/CUE-569
Slack thread: https://pagerduty.slack.com/archives/CGJB5TDL7/p1564154727080600

## Tests
I added some tests with this change.  Should we enable CI for this library.  I feel like we should since this sits in front of pretty much all of our phoenix applications